### PR TITLE
Ensure issue title is quote-escaped since it will contain a colon

### DIFF
--- a/.github/workflows/create-newsletter-issue.yaml
+++ b/.github/workflows/create-newsletter-issue.yaml
@@ -30,5 +30,5 @@ jobs:
       - name: Create an issue
         uses: peter-evans/create-issue-from-file@v5
         with:
-          title: ${{ steps.generate-text.output.ISSUE_TITLE }}
+          title: "${{ steps.generate-text.output.ISSUE_TITLE }}"
           content-filepath: .github/resources/output.md


### PR DESCRIPTION
The automated workflow to create a newsletter issue failed. This PR is part of debugging that failure, but I can only test it by pushing to main and running.